### PR TITLE
feat: expose closest as a nix package and fix version stamping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,16 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
+
+  nix-build:
+    name: Nix build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - name: Build
+        run: nix build .#

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.direnv/
+result
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,10 @@
 version: 2
 
 builds:
-  - ldflags: -s -w -X "corrupt952/closest.Version={{.Version}}"
+  # The main package's link symbol is main.Version; the module-path form
+  # ("corrupt952/closest.Version") silently stamps nothing, which is why
+  # released binaries used to print an empty version.
+  - ldflags: -s -w -X "main.Version={{.Version}}"
     goos:
       - linux
       - darwin

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ curl -L https://github.com/corrupt952/closest/releases/latest/download/closest_l
 sudo mv closest /usr/local/bin/
 ```
 
+### Nix
+
+```sh
+# Run without installing
+nix run github:corrupt952/closest -- --help
+
+# Install into your profile
+nix profile install github:corrupt952/closest
+```
+
+Builds from source on the current main; `closest -v` reports the commit hash it was built from.
+
 ### Install via aqua
 
 If you use [aqua](https://github.com/aquaproj/aqua), you can install `closest` with:

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784103219,
-        "narHash": "sha256-MyxoglQA10PAmtH4X8XA38Js2pryooWH7oSAfHRKGHU=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f8dc94623d99b76cbe2ba5c9d83b465aab073d30",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-26.05-darwin",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,9 @@
 {
-  description = "closest development environment";
+  description = "CLI tool that searches parent directories for files and returns the closest path";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { nixpkgs, ... }:
+  outputs = { self, nixpkgs, ... }:
     let
       systems = [
         "aarch64-darwin"
@@ -12,8 +12,35 @@
         "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
+      # Prefer the commit hash over a hand-maintained version: it can never
+      # go stale, and `nix run github:corrupt952/closest` always builds main.
+      version = self.shortRev or self.dirtyShortRev or "dev";
     in
     {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.buildGoModule {
+            pname = "closest";
+            inherit version;
+            src = pkgs.lib.cleanSource self;
+            vendorHash = null;
+            # Keep in sync with .goreleaser.yml ldflags.
+            ldflags = [ "-s" "-w" "-X" "main.Version=${version}" ];
+            # The finder tests walk up parent directories from the working
+            # directory, which makes them sensitive to the sandbox's directory
+            # layout. CI runs `go test` directly.
+            doCheck = false;
+            meta.mainProgram = "closest";
+          };
+        });
+
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.default;
+      });
+
       devShells = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
## Summary
- Add a `packages` output to the flake (buildGoModule) so `nix run github:corrupt952/closest` and `nix profile install github:corrupt952/closest` work out of the box
- Stamp the binary with the commit hash it was built from (`closest -v` → e.g. `closest version 4df663c`)
- Add `checks` output and a CI `nix-build` job (catches flake build breakage on PRs)
- Move the nixpkgs input from `nixpkgs-26.05-darwin` to `nixos-unstable` — the darwin-specific stable branch is the wrong pin for a flake that also targets linux, and that branch family has had version-mismatch issues (NixOS/nixpkgs#409677)
- Add a Nix section to the README installation docs

## Bug fix: release binaries print an empty version
The goreleaser ldflags used the module-path form (`corrupt952/closest.Version`), which silently stamps nothing — the released v1.1.0 darwin_arm64 binary prints `closest version ` (verified by downloading the asset). The main package's link symbol is `main.Version`; both the flake and `.goreleaser.yml` now use it. Verified with `goreleaser release --snapshot`: `closest version 1.1.0-SNAPSHOT-a481a3b`.

## Notes
- The flake build skips `go test` (`doCheck = false`): the finder tests walk up parent directories from the working directory and fail inside the Nix build sandbox. Tests keep running in the existing CI matrix.
- Same approach as corrupt952/xckit (flake packages output added on main today); survey of current practice (lazygit/tailscale/headscale flakes, GoReleaser nix publisher docs) showed in-repo flake + buildGoModule is the standard path for small Go CLIs, and GoReleaser's `nix:` publisher (NUR + fetchurl of release binaries) is a different, rarely-used mechanism.

## Test plan
- [x] `nix build .#` succeeds (darwin arm64) and `./result/bin/closest -v` prints the commit hash
- [x] `goreleaser release --snapshot` binary prints the semver version
- [x] `nix flake check` passes for the current system
- [ ] CI: existing test matrix + new nix-build job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)