### PR TITLE
ci: harden GitHub Actions workflows and add Makefile/golangci-lint config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,8 +2,5 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "github>corrupt952/renovate-config:default.json5",
-
-    // CAUTION: This repository has no tests, so skip status checks
-    ":skipStatusChecks"
   ],
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,19 +8,45 @@ on:
 permissions:
   contents: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.26
+          # A tag-triggered release build is a poor fit for the module/build
+          # cache: it runs once per tag and is exactly the kind of workflow
+          # cache-poisoning attacks target.
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: latest
-          args: release
+          # A semver range instead of "latest" so a GoReleaser major bump
+          # can't silently change release behavior underneath a tag push.
+          version: "~> v2"
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          # GoReleaser's default checksum filename is version-prefixed
+          # (closest_<version>_checksums.txt), not a fixed checksums.txt.
+          subject-checksums: dist/*_checksums.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     name: Test
@@ -18,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -26,7 +32,7 @@ jobs:
           cache: true
 
       - name: Test
-        run: go test -v ./...
+        run: make test
 
   lint:
     name: Lint
@@ -34,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -44,7 +52,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: latest
+          version: v2.12.2
 
   nix-build:
     name: Nix build
@@ -52,9 +60,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
       - name: Build
         run: nix build .#
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+VERSION ?= 0.0.0
+LDFLAGS ?= -ldflags "-s -w -X 'main.Version=$(VERSION)'"
+
+# HACK: make [target] [ARGS...]
+ARGS = $(filter-out $@,$(MAKECMDGOALS))
+
+# HACK: nothing undefined target
+%:
+	@:
+
+all: run
+
+run:
+	go run $(LDFLAGS) . $(ARGS)
+
+build:
+	go build $(LDFLAGS) -o closest .
+
+fmt:
+	@go fmt ./...
+
+test:
+	@go test -v ./...
+
+lint:
+	@golangci-lint run
+
+clean:
+	@rm -f closest
+
+install: build
+	@mv closest $(GOPATH)/bin/ || mv closest /usr/local/bin/
+
+.PHONY: all run build fmt test lint clean install


### PR DESCRIPTION
## Summary
- Add a Makefile (run/build/test/lint/install), matching xckit/sallyport, and unify local/CI test execution behind `make test`
- Add `.golangci.yml` and pin the lint action to v2.12.2 (no new findings under the tightened config)
- Harden GitHub Actions per zizmor + current supply-chain best practices: `persist-credentials: false` on every checkout, `defaults.run.shell: bash`, top-level `permissions: contents: read` on test.yml (previously unset), release workflow disables the setup-go cache (cache-poisoning mitigation for a tag-triggered one-shot build), pins goreleaser-action to a semver range instead of `latest`, adds `fetch-depth: 0` + `timeout-minutes`, and attests build provenance for the release checksums via `actions/attest-build-provenance`
- Add a `zizmor` CI job (zizmorcore/zizmor-action)

Companion change to the same work done on [corrupt952/sallyport](https://github.com/corrupt952/sallyport).

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `make test` (one pre-existing, environment-sensitive failure in `finder_test.go` reproduces identically on `main`, unrelated to this change — see PR comment)
- [x] `nix run nixpkgs#golangci-lint -- run` — 0 issues
- [x] `nix run nixpkgs#zizmor -- .github/workflows/` — no findings
- [x] `nix run nixpkgs#actionlint -- .github/workflows/*.yml .github/workflows/*.yaml` — no findings
- [x] `goreleaser release --snapshot --clean` — verified checksums filename matches the attestation glob
- [ ] CI green on this PR